### PR TITLE
Improvement to reset function and minor adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+src/main/java/burp/api
+target/

--- a/src/main/java/com/staticflow/Utils.java
+++ b/src/main/java/com/staticflow/Utils.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
 public class Utils {
 
     private static final String SEARCH = "Search";
+    private static final String RESET = "Reset";
     private static final String ENTER_QUERY = "Enter query...";
     private static boolean searchResponseForText = false;
     private static boolean searchRequestForText = true;
@@ -90,8 +91,9 @@ public class Utils {
         JPanel searchBarPanel = new JPanel(new GridBagLayout());
         JPanel searchBarButtonsPanel = new JPanel();
         searchBarButtonsPanel.setLayout(new BoxLayout(searchBarButtonsPanel,
-                BoxLayout.Y_AXIS));
+                BoxLayout.X_AXIS));
         JButton searchButton = new JButton(SEARCH);
+        JButton resetButton = new JButton(RESET);
         JTextField searchBar = new JTextField(ENTER_QUERY);
         GridBagConstraints c = new GridBagConstraints();
 
@@ -123,6 +125,8 @@ public class Utils {
         //BUILD SEARCH SUBMIT AND FILTER COMPONENTS
         searchButton.addActionListener(e -> searchRepeaterTabsForString(searchBar.getText()));
         searchBarButtonsPanel.add(searchButton);
+        resetButton.addActionListener(e -> resetRepeaterTabs());
+        searchBarButtonsPanel.add(resetButton);
         JCheckBox searchRequest = new JCheckBox("Request");
         searchRequest.setSelected(true);
         searchRequest.addChangeListener(e -> searchRequestForText = !searchRequestForText);
@@ -157,22 +161,26 @@ public class Utils {
         JTabbedPane repeaterTabs = ExtensionState.getInstance().getRepeaterTabbedPane();
         ExtensionState.getInstance().getCallbacks().logging().logToOutput("Searching for: "+search);
         for( int i=0; i < repeaterTabs.getTabCount(); i++) {
-            repeaterTabs.setBackgroundAt(i,new Color(0xBBBBBB));
-            List<Component> repeaterTabRequestResponseJTextAreas = BurpGuiControl.findAllComponentsOfType((Container) repeaterTabs.getComponentAt(i), JTextArea.class);
+            try{
+                repeaterTabs.setBackgroundAt(i,new Color(0xBBBBBB));
+                List<Component> repeaterTabRequestResponseJTextAreas = BurpGuiControl.findAllComponentsOfType((Container) repeaterTabs.getComponentAt(i), JTextArea.class);
 
-            if ( searchRequestForText ) {
-                JTextArea requestTextArea = (JTextArea) repeaterTabRequestResponseJTextAreas.get(0);
-                ExtensionState.getInstance().getCallbacks().logging().logToOutput(requestTextArea.getText());
-                if (searchTextArea(search,requestTextArea) ) {
-                    repeaterTabs.setBackgroundAt(i,new Color(0xff6633));
+                if ( searchRequestForText ) {
+                    JTextArea requestTextArea = (JTextArea) repeaterTabRequestResponseJTextAreas.get(0);
+                    ExtensionState.getInstance().getCallbacks().logging().logToOutput(requestTextArea.getText());
+                    if (searchTextArea(search,requestTextArea) ) {
+                        repeaterTabs.setBackgroundAt(i,new Color(0xff6633));
+                    }
                 }
-            }
-            if ( searchResponseForText ) {
-                JTextArea responseTextArea = (JTextArea) repeaterTabRequestResponseJTextAreas.get(1);
-                ExtensionState.getInstance().getCallbacks().logging().logToOutput(responseTextArea.getText());
-                if (searchTextArea(search, responseTextArea)) {
-                    repeaterTabs.setBackgroundAt(i,new Color(0xff6633));
+                if ( searchResponseForText ) {
+                    JTextArea responseTextArea = (JTextArea) repeaterTabRequestResponseJTextAreas.get(1);
+                    ExtensionState.getInstance().getCallbacks().logging().logToOutput(responseTextArea.getText());
+                    if (searchTextArea(search, responseTextArea)) {
+                        repeaterTabs.setBackgroundAt(i,new Color(0xff6633));
+                    }
                 }
+            }catch(Exception e){
+                ExtensionState.getInstance().getCallbacks().logging().logToOutput(e.getMessage());
             }
         }
     }
@@ -183,7 +191,7 @@ public class Utils {
     private static void resetRepeaterTabs(){
         JTabbedPane repeaterTabs = ExtensionState.getInstance().getRepeaterTabbedPane();
         for(int i=0; i < repeaterTabs.getTabCount(); i++) {
-            repeaterTabs.setBackgroundAt(i,new Color(0xBBBBBB));
+            repeaterTabs.setBackgroundAt(i,new Color(0x000000));
         }
     }
 


### PR DESCRIPTION
I've added these changes:
- Add reset button to manually reset tabs
- Resetting change tab color to black instead of grey
- Add exception handling to deal with tab group header
- Change orientation of button pane from vertical to horizontal

Old: Only tabs before groups are highlighted due to exception occuring at the group header (Group 1 label)
![image](https://github.com/Static-Flow/RepeaterSearch/assets/50922013/db1f288b-8ab4-4aec-9e38-d5caa8d7703a)

New: tabs inside and after groups are highlighted, leaner search bar
![image](https://github.com/Static-Flow/RepeaterSearch/assets/50922013/1201cbff-46e9-4af4-a20c-18777377768c)
